### PR TITLE
fix: drop the module, lambda runtime error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/pr-remove.yml
+++ b/.github/workflows/pr-remove.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: "npm"
       - name: Install dependencies
         run: npm ci

--- a/website/package.json
+++ b/website/package.json
@@ -2,6 +2,7 @@
   "name": "website",
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "license": "MIT",
   "dependencies": {
     "express": "^4.19.2",

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,6 @@
   "name": "website",
   "version": "1.0.0",
   "main": "index.js",
-  "type": "module",
   "license": "MIT",
   "dependencies": {
     "express": "^4.19.2",


### PR DESCRIPTION
The `"type": "module"` in the `package.json` was causing the lambda function to throw the error `SyntaxError: Cannot use import statement outside a module`. Dropping this fixes the lambda and the site.